### PR TITLE
282 user can enter a user name while adding an expense

### DIFF
--- a/__tests__/Rx_test.re
+++ b/__tests__/Rx_test.re
@@ -4,13 +4,14 @@ open Expect;
 
 open Js.Promise;
 
-let buildWebhook = id : Webhook.t => {
+let buildWebhook = id: Webhook.t => {
   id,
   name: "test",
   url: "url1",
   event: OrderPaid,
   source: Order,
   behavior: FireAndForget,
+  payload: Json,
 };
 
 describe("The Webhook Store", () =>
@@ -25,7 +26,7 @@ describe("The Webhook Store", () =>
       let stream = webhooksPromise |> Rx.promiseWithListToStream;
       stream
       |> Most.observe(w => Js.log(w))
-      |> then_((_) => {
+      |> then_(_ => {
            Js.log("Stream completed");
            finish(expect(1) |> toBe(1));
            Js.Promise.resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -564,7 +564,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -684,7 +684,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -985,8 +985,8 @@
       }
     },
     "cafe-domain": {
-      "version": "github:bsommardahl/cafe-domain#c7ca0cc77f3b1011fc9afe378d3e7934f070a1c5",
-      "from": "github:bsommardahl/cafe-domain",
+      "version": "github:bsommardahl/cafe-domain#1d4c7d302d5086a90b01475ce41355c37ed9f34b",
+      "from": "github:bsommardahl/cafe-domain#282-user-can-enter-a-user-name-while-adding-an-expense",
       "dev": true
     },
     "callsites": {
@@ -3891,7 +3891,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -6117,7 +6117,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   },
   "peerDependencies": {
     "bs-most": "github:bsommardahl/bs-most",
-    "cafe-domain": "github:bsommardahl/cafe-domain"
+    "cafe-domain": "github:bsommardahl/cafe-domain#282-user-can-enter-a-user-name-while-adding-an-expense"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.3",
     "bs-most": "github:bsommardahl/bs-most",
     "bs-platform": "^4.0.5",
-    "cafe-domain": "github:bsommardahl/cafe-domain"
+    "cafe-domain": "github:bsommardahl/cafe-domain#282-user-can-enter-a-user-name-while-adding-an-expense"
   }
 }

--- a/src/UserStore.re
+++ b/src/UserStore.re
@@ -1,0 +1,69 @@
+open Js.Promise;
+
+open PouchdbImpl;
+
+let connection = DbHelper.init("users");
+
+type item = User.t;
+type newItem = User.New.t;
+
+let id = (item: item) => item.id;
+
+let db = connection.local;
+
+let add = (newUser: User.New.t) =>
+  db
+  |> post(newUser |> User.New.toJs)
+  |> then_(revResponse =>
+       db
+       |> get(revResponse##id)
+       |> then_(js => {
+            let o = js |> User.fromJs;
+            Js.log("UserStore:: added new User for " ++ newUser.name);
+            resolve(o);
+          })
+     );
+
+let getAll = () =>
+  db
+  |> find(
+       Pouchdb.QueryBuilder.query(~selector={
+                                    "_id": {
+                                      "$gt": Js.null,
+                                    },
+                                  }, ()),
+     )
+  |> then_(response => resolve(response##docs))
+  |> then_(docs => {
+       let mapped: array(User.t) = docs |> Array.map(d => User.fromJs(d));
+       Js.log(
+         "UserStore:: got Users: " ++ string_of_int(docs |> Array.length),
+       );
+       resolve(mapped);
+     })
+  |> then_(expenses => resolve(Array.to_list(expenses)));
+
+let update = (expense: User.t): Js.Promise.t(User.t) =>
+  db
+  |> get(expense.id)
+  |> then_(js => {
+       let modified = expense |> User.toJsWithRev(js##_id, js##_rev);
+       db
+       |> put(modified)
+       |> then_(_rev => {
+            Js.log("UserStore:: updated User for " ++ js##name);
+            resolve(expense);
+          });
+     });
+
+let remove = (~id: string): t(unit) =>
+  db
+  |> PouchdbImpl.get(id)
+  |> then_(item =>
+       db
+       |> remove(item)
+       |> then_(_ => {
+            Js.log("UserStore:: removed User with id: " ++ id);
+            resolve();
+          })
+     );


### PR DESCRIPTION
This PR should be merged first:
- https://github.com/bsommardahl/cafe-domain/pull/3

Once it has been merged, the [package.json](https://github.com/bsommardahl/cafe-data/blob/282-user-can-enter-a-user-name-while-adding-an-expense/package.json) should be updated the following way:

```diff
 {
    "dependencies": {
-         "cafe-domain": "github:bsommardahl/cafe-domain#282-user-can-enter-a-user-name-while-adding-an-expense",
+         "cafe-domain": "github:bsommardahl/cafe-domain",
    }
 }
```

After all that's done, this PR can be merged.